### PR TITLE
Adding initial Slack bot GHA config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,14 @@ jobs:
           lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+  slack:
+    name: Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sends Slack notification
+        uses: Ilshidur/action-slack@2.0.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          args: 'This message is generated from a GitHub Action!'
+


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes n/a

---

## :construction_worker: Changes

- Added initial GitHub Action job for sending a Slack notification

## :thought_balloon: Notes

- Still need to grab the URL and figure out where (i.e., what channels) and when this should trigger

## :flashlight: Testing Instructions

- See [this](https://github.com/Ilshidur/action-slack/blob/2.0.2/DEVELOPMENT.md) for local testing
